### PR TITLE
Restore exact structure lookup

### DIFF
--- a/django_rdkit/models/fields.py
+++ b/django_rdkit/models/fields.py
@@ -335,8 +335,8 @@ class SameStructure(MolLookupMixin, Lookup):
         lhs, lhs_params = self.process_lhs(qn, connection)
         rhs, rhs_params = self.process_rhs(qn, connection)
         params = lhs_params + rhs_params
-        #return '%s @= %s' % (lhs, rhs), params
-        return '%s <@ %s AND %s @> %s' % (lhs, rhs, lhs, rhs), params + params
+        return '%s @= %s' % (lhs, rhs), params
+        #return '%s <@ %s AND %s @> %s' % (lhs, rhs, lhs, rhs), params + params
 
 MolField.register_lookup(SameStructure)
 


### PR DESCRIPTION
Restores exact structure lookup to use the exact match operator (`@=`) instead of 2 substructure search operators (`@>` and `<@`).

As mentioned in the comments, the initial issue in the cartridge which prompted the workaround of using 2 substructure searches has been resolved quite some time ago, and the restoration of the lookup logic makes sense now.

I've also encountered an issue, where searching for exact matches of molecules with multiple small parts (like ammonium cerium(IV) nitrate) causes the search query to run for hours. With the use of the `@=` operator, this issue does not come up.